### PR TITLE
add templates for creating summary tables and building a snapshot

### DIFF
--- a/summary-tables-redshift.py
+++ b/summary-tables-redshift.py
@@ -53,49 +53,15 @@ group by 1
 '''
 
 # execute command to create a new table
-# log any exceptions as an error
 
 try:
     cur.execute(create_table)
     logger.info('Successfully executed CREATE TABLE AS command')
-except Exception as e: 
-    logger.error(e)
-    cur.close()
 
 # make the changes to the database persistent
-# log any exceptions as an error
-# and close communication with the database
-
-try:
     rs.commit()
     logger.info('Successfully committed changes to the database')
-except Exception as e: 
-    logger.error(e)
+
+finally:
     cur.close()
     rs.close()
-
-# verify the changes persisted
-# log any exceptions as an error
-# and close communication with the database
-
-
-query = '''
-select *
-from build_summary_table
-order by total_connections asc
-'''
-
-try:
-    cur.execute(query)
-#     resultdata = cur.fetchall()
-#     pp.pprint(resultdata)
-    logger.info('Successfully queried the newly created table from the database')
-except Exception as e:
-    logger.error(e)
-    cur.close()
-    rs.close()
-
-# close communication with the database
-
-cur.close()
-rs.close()

--- a/summary-tables-redshift.py
+++ b/summary-tables-redshift.py
@@ -19,7 +19,7 @@ create or replace view build_summary_table as (
 with a as (
 select
 cid as primary_key
-from platform.rjm_clients
+from schema_a.table_a
 limit 100
 )
 ,
@@ -27,8 +27,8 @@ limit 100
 b as (
 select 
 client_id as foreign_key, 
-count(*) as total_connections 
-from connection_service.connections 
+count(*) as total
+from schema_b.table_b
 group by 1 
 order by 2 desc
 )
@@ -37,14 +37,14 @@ order by 2 desc
 c as (
 select
 a.*,
-nvl(b.total_connections,0) as total_connections
+nvl(b.total,0) as total
 from a
 left join b
 on a.primary_key = b.foreign_key
 )
 
 select
-total_connections,
+total,
 count(*)
 from c
 group by 1

--- a/summary-tables-redshift.py
+++ b/summary-tables-redshift.py
@@ -1,0 +1,101 @@
+import psycopg2
+import psycopg2.extras
+import pprint as pp
+import logging
+import pandas
+
+logger = logging.getLogger()
+
+rs = connections['Default Warehouse']['client']
+cur = rs.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+
+# build command to create a new table
+# use CREATE OR REPLACE VIEW name AS in order to avoid conflicts when trying to replace data
+# https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_VIEW.html
+
+create_table = '''
+create or replace view build_summary_table as (
+
+with a as (
+select
+cid as primary_key
+from platform.rjm_clients
+limit 100
+)
+,
+
+b as (
+select 
+client_id as foreign_key, 
+count(*) as total_connections 
+from connection_service.connections 
+group by 1 
+order by 2 desc
+)
+,
+
+c as (
+select
+a.*,
+nvl(b.total_connections,0) as total_connections
+from a
+left join b
+on a.primary_key = b.foreign_key
+)
+
+select
+total_connections,
+count(*)
+from c
+group by 1
+
+);
+'''
+
+# execute command to create a new table
+# log any exceptions as an error
+
+try:
+    cur.execute(create_table)
+    logger.info('Successfully executed CREATE TABLE AS command')
+except Exception as e: 
+    logger.error(e)
+    cur.close()
+
+# make the changes to the database persistent
+# log any exceptions as an error
+# and close communication with the database
+
+try:
+    rs.commit()
+    logger.info('Successfully committed changes to the database')
+except Exception as e: 
+    logger.error(e)
+    cur.close()
+    rs.close()
+
+# verify the changes persisted
+# log any exceptions as an error
+# and close communication with the database
+
+
+query = '''
+select *
+from build_summary_table
+order by total_connections asc
+'''
+
+try:
+    cur.execute(query)
+#     resultdata = cur.fetchall()
+#     pp.pprint(resultdata)
+    logger.info('Successfully queried the newly created table from the database')
+except Exception as e:
+    logger.error(e)
+    cur.close()
+    rs.close()
+
+# close communication with the database
+
+cur.close()
+rs.close()

--- a/table-snapshot-bigquery.py
+++ b/table-snapshot-bigquery.py
@@ -1,0 +1,92 @@
+import pandas
+
+import pprint as pp
+pp.pprint(connections)
+
+import logging
+logger = logging.getLogger()
+
+from google.cloud import bigquery
+client = connections['Default Warehouse']['client']
+
+# # DO ONLY ONCE
+# # create a new dataset for your daily snapshots
+
+# dataset_ref = client.dataset('snapshots_dataset')
+
+# dataset = bigquery.Dataset(dataset_ref)
+# dataset.location = 'US'
+# client.create_dataset(dataset)
+
+# # DO ONLY ONCE
+# # create a new table
+
+# table_ref = dataset_ref.table('shakespeare_daily')
+# table = bigquery.Table(table_ref)
+# table = client.create_table(table)  # API request
+
+# assert table.table_id == 'shakespeare_daily'
+
+# get info on destination dataset
+
+dataset_ref = client.dataset('snapshots_dataset')
+
+# Retrieves the destination table and checks the length of the schema
+table_id = 'shakespeare_daily'
+table_ref = dataset_ref.table(table_id)
+table = client.get_table(table_ref)
+
+print("Table {} contains {} columns.".format(table_id, len(table.schema)))
+logger.info("Table {} contains {} columns.".format(table_id, len(table.schema)))
+
+# configure the query to append the results to a destination table,
+# allowing field addition
+
+try:
+    job_config = bigquery.QueryJobConfig()
+    job_config.schema_update_options = [
+        bigquery.SchemaUpdateOption.ALLOW_FIELD_ADDITION,
+    ]
+    job_config.destination = table_ref
+    job_config.write_disposition = bigquery.WriteDisposition.WRITE_APPEND
+except Exception as e:
+    logger.error(e)
+
+query_job = client.query(
+    
+#     select everything from your source dataset
+#     and add a created_at column with the current timestamp
+    'SELECT *, CURRENT_DATETIME() as created_at from `bigquery-public-data.samples.shakespeare`;', # current_datetime returns UTC timestamp
+    
+# Location must match that of the dataset(s) referenced in the query
+# and of the destination table.
+    location='US',
+    job_config=job_config
+
+)  
+
+try:
+    query_job.result()  # Waits for the query to finish
+    print("Query job {} complete.".format(query_job.job_id))
+    logger.info("Query job {} complete.".format(query_job.job_id))
+except Exception as e:
+    logger.error(e)
+
+# check the updated length of the schema
+
+table = client.get_table(table)
+
+print("Table {} now contains {} columns.".format(table_id, len(table.schema)))
+logger.info("Table {} now contains {} columns.".format(table_id, len(table.schema)))
+
+# look at the new timestamps
+
+import pandas
+bq = connections['Default Warehouse']['client']
+sql = """
+    select distinct created_at
+    from snapshots_dataset.shakespeare_daily
+    limit 10
+"""
+
+bq.query(sql).to_dataframe()

--- a/table-snapshot-bigquery.py
+++ b/table-snapshot-bigquery.py
@@ -81,12 +81,10 @@ logger.info("Table {} now contains {} columns.".format(table_id, len(table.schem
 
 # look at the new timestamps
 
-import pandas
-bq = connections['Default Warehouse']['client']
 sql = """
     select distinct created_at
     from snapshots_dataset.shakespeare_daily
     limit 10
 """
 
-bq.query(sql).to_dataframe()
+client.query(sql).to_dataframe()

--- a/transform-table-snowflake.py
+++ b/transform-table-snowflake.py
@@ -1,0 +1,19 @@
+import logging
+logger = logging.getLogger()
+
+import pprint as pp
+pp.pprint(connections)
+
+# build transformation query
+
+cnx = connections['Default Warehouse']['client']
+cur = cnx.cursor()
+
+try:
+    sql = cur.execute("CREATE OR REPLACE TABLE chicken.burger.daily_14_agg AS SELECT count(*) as total FROM snowflake_sample_data.weather.daily_14_total")
+    logger.info('Created aggregate table.')
+except Exception as e:
+    logger.error(e)
+finally:
+    logger.info('Closing connection.')
+    cur.close()


### PR DESCRIPTION
`summary-tables-redshift.py`
Replaces or creates a new view in Redshift with a query built across tables. Can be run at regular intervals or after data loads in order to refresh data models.

`table-snapshot-bigquery.py`
Selects all of the data from a given source table and appends it to a destination table with the current timestamp. This deals with schema changes by appending columns that did not previously exist to the dataset.